### PR TITLE
fixing doubled id in outbound-no-comittment

### DIFF
--- a/agreement-template-unified.html
+++ b/agreement-template-unified.html
@@ -110,7 +110,7 @@ Country</p>
 
 </section>
 
-<section id="tmp-outbound-section-all">
+<section id="tmp-outbound-section-all" class="tmp-outbound-section">
 
 <h3>4. License obligations by Us </h3>
 

--- a/js/chooser.js
+++ b/js/chooser.js
@@ -884,12 +884,12 @@ function setOutboundOptionNoCommitment ()
     $("#review-outbound-license-options").html(
         $("#outbound-option-no-commitment").val() );
     */
-
-
+    
     /* remove entire section 4 */
-    $("#tmp-outbound-section-all").hide();
-    $("#tmp-outbound-section-all").addClass("nuke");
-    // entire section hidden: fixPatentParagraph();
+    // entire section hidden: fixPatentParagraph(); @TODO can this go?
+    // no multiple ids in one page... 
+    $('.tmp-outbound-section').hide();
+    $('.tmp-outbound-section').addClass("nuke");
 
     /* reorder sections now that section 4 gone */
     $('#review-text #tmp-digit-disclaimer').html( '4.' );


### PR DESCRIPTION
IDs are supposed to be unique per document, and jquery will use getElementByID which only gets the first ID. As the template is inserted into the document at least twice, only the first version got modified. As a fix, I added a class to the outbound-no-commitment section of the document, and nuked/hid that instead of the ID.
Fixes #17 

Might have to check everything if this happens for other cases too.