### PR TITLE
Fixing the non-functioning query url for fla/non-fla and outbound-option-3

### DIFF
--- a/doc-todo.md
+++ b/doc-todo.md
@@ -1,9 +1,0 @@
-DOCS / TODO / FIXME 
-
-* the plan was to have one unified agreement template file, as differences between them are negligible or non existant apart from options iirc
-
-* this unified template file should be ready and should look better than before, though always good to check.
-
-* Introduced code to display FLA at the end, which should work and a toggle button at the front which should disable some stuff/choose some default options and maybe change thins at the end. The Button is there, but is not fully functional if I remember correctly
-
-* at some point, also to accompany new look an update to bootstrap3 would be nice, but this breaks things

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
 <div id="agreement-exclusivity-non-fsfe">
     <label for="agreement-exclusivity" id="agreement-exclusivity-label" data-toggle="popover" data-trigger="hover" title="Type of Inbound License" data-content="You can choose between an exclusive license and a non-exclusive license. A non-exclusive license is the right to use the contribution on a non-exclusive basis, meaning that the contributor can also grant a license to someone else to use the same contribution. An exclusive license means that no other person or company can use the contribution including the contributor himself, which is why is the exclusive license option implies a non-exclusive license back to the contributor to allow him to exploit his contribution.">Which style of contributor agreement (in regard to inbound licensing) would you like to create?</label>
     <select id="agreement-exclusivity" name="agreement-exclusivity" class="input-block-level">
-<option value="exclusive">Exclusive License</option>
+<option id="exclusive" value="exclusive">Exclusive License</option>
 <option id="non-exclusive" value="non-exclusive">Non-Exclusive License</option>
 </select>
 </div>

--- a/js/chooser.js
+++ b/js/chooser.js
@@ -282,11 +282,16 @@ function updateConfigs ()
             configs["project-jurisdiction"]);
 
     /* fsfe compliance changes */
-    // TODO move button change here? FIXME this is right, but what is the other fsfeCompliance doing?
     if ( configs["fsfe-compliance"] == "fsfe-compliance" ) {
       $('#fsfe-compliance').val(configs["fsfe-compliance"] );
+        $('#non-fsfe-compliance').val('');
+        $('#fsfe-compliance').addClass('active');
+        $('#non-fsfe-compliance').removeClass('active');
     } else {
-        $('#fsfe-compliance').val(configs["fsfe-compliance"] );
+        $('#fsfe-compliance').val('');
+        $('#non-fsfe-compliance').val(configs["fsfe-compliance"] );
+        $('#non-fsfe-compliance').addClass('active');
+        $('#fsfe-compliance').removeClass('active');
     }
     if ( doDebug )
         console.log("fsfe-compliance: " +
@@ -300,10 +305,6 @@ function updateConfigs ()
     if ( doDebug )
         console.log("agreement-exclusivity: " +
             configs["agreement-exclusivity"]);
-
-
-    if ( configs["outbound-option"] == 'same' )
-        $("#contributor-option-individual").prop('checked', true );
 
     // hide by default
     $("#outboundlist").hide();
@@ -331,15 +332,8 @@ function updateConfigs ()
         case 'license-policy':
             $("#outbound-option-license-policy").prop('checked', true);
             $("#outbound-option-license-policy").change();
-            if ( configs["license-policy"] )
-                 $("#license-policy-location" ).val( configs["license-policy-location"] );
-            break;
-        // option-5
-        case 'no-commitment':
-            $("#outbound-option-no-commitment").prop('checked', true );
-            $("#outbound-option-no-commitment" ).trigger( 'change' );
-            // @todo delete later if no need
-            // setOutboundOptionNoCommitment();
+            $("#license-policy-location").show();
+            $("#license-policy-location" ).val( configs["license-policy-location"] );
             break;
         // option-4
         case 'same':
@@ -348,6 +342,13 @@ function updateConfigs ()
             $("#outbound-option-same" ).trigger( 'change' );
             // @todo delete later if no need
             // setOutboundOptionSame();
+        // option-5
+        case 'no-commitment':
+            $("#outbound-option-no-commitment").prop('checked', true );
+            $("#outbound-option-no-commitment" ).trigger( 'change' );
+            // @todo delete later if no need
+            // setOutboundOptionNoCommitment();
+            break;
     }
 
     if ( doDebug )
@@ -861,6 +862,10 @@ function setOutboundOptionSameLicenses ()
 
   function setOutboundOptionLicensePolicy ()
 {
+    configs['outbound-option'] = 'license-policy';
+    if ( !!$('#license-policy-location').val() ) {
+    configs['license-policy-location'] = $("#license-policy-location").val();
+    }
     // sets the value of the license policy on the review tab to the value of the input on the copyright tab
     $("#review-outbound-licenses").html(
       $("#outbound-option-license-policy").val() );
@@ -1109,19 +1114,6 @@ function testGeneralPage ()
             } else {
                 $('#project-jurisdiction').removeClass("cla-alert");
             }
-            // FIXME this spelling is the only usage here. so likely it should be fixed or removed.
-            /*var something = $('#fsfe-compliance').val()
-            console.log(`fsfe-compliance general page ${something}`)
-            if ($('#fsfe-compliance').val() == 'fsfe-compliance'  ) {
-                fsfeCompliance = "fsfe-compliance"
-                console.log('fsfe compliance set on general page')
-            } else if ($('non-fsfe-compliance').val() || ) {
-                fsfeCompliance = "non-fsfe-compliance"
-                console.log('non-fsfe-compliance set on general page')
-            } else {
-                console.log('neither fsfe or non-fsfe compliance set. this should probably never happen.')
-            } */
-    
 
 
     testReviewPage();
@@ -1171,6 +1163,7 @@ function testCopyrightPage ()
                 LicensePolicyLocation = "";
             } else {
                 LicensePolicyLocation = $('#license-policy-location').val();
+
             }
 
             // FIXME
@@ -1446,7 +1439,7 @@ function testReviewPage ()
                 $('#review-text-entity #tmp-license-back').addClass("nuke");
             }
 
-            // inserts the fsfeField into the possivble licenses FIXME - if this is not even checked, why is this not fixed in text?
+            // inserts the fsfeField into the possible licenses FIXME - if this is not even checked, why is this not fixed in text?
             $('#review-text-fla #tmp-licenses-2').html( fsfeField );
             $('#review-text-fla-entity #tmp-licenses-2').html( fsfeField );
             // If not outbound copyright licenses are set, insert a blank space into the text
@@ -1801,28 +1794,32 @@ $(document).ready(function() {
 
     // These are meant to update the configs or run functions if an input field changes. FIXME Only some are used.
     $( "#beneficiary-name" ).change(function() {
+        configs["beneficiary-name"] = $("#beneficiary-name").val();
         // return testGeneralPage();
     });
 
     $( "#project-name" ).change(function() {
+        configs["project-name"] = $("#project-name").val();
         // return testGeneralPage();
     });
 
     $( "#project-website" ).change(function() {
+        configs["project-website"] = $("#project-website").val();
         // return testGeneralPage();
     });
 
     $( "#project-email" ).change(function() {
         configs["project-email"] = $( "#project-email" ).val();
-
         // return testGeneralPage();
     });
 
     $( "#contributor-process-url" ).change(function() {
+        configs("process-url") = $("#contributor-process-url").val();
         // return testGeneralPage();
     });
 
     $( "#project-jurisdiction" ).change(function() {
+        configs["project-jurisdiction"] = $("#project-jurisdiction").val();
         // return testGeneralPage();
     });
 
@@ -1840,16 +1837,17 @@ $(document).ready(function() {
     });
 
     // This sets the default FSFE compliant status by default
+    if (!configs["fsfe-compliance"] || configs["fsfe-compliance"] === "fsfe-compliance") {
     $("#fsfe-compliance").button("toggle"); // this is needed to set the default button to the green fsfe compliance
     selectFsfeCompliance(); // this is needed for fsfe compliance to activate / ui changes to happen without clicking the fsfe button
-
-    // this should prob be under general page (and maybe use change for consistency)
-    $( "#fsfe-compliance").click(function() {
-        selectFsfeCompliance();
-    });
+    }
+    else {
+        // or just set relevant agreement buttons to hidden?
+        selectNonFsfeCompliance();
+    }
 
     /*
-     * Select all options for FSFE Compliance. FIXME should this be here or under testGeneral page or similar at least not directly after document load.
+     * Select all options for FSFE Compliance. FIXME should this be here or under testGeneral page?
      */
     function selectFsfeCompliance ()
     {
@@ -1876,12 +1874,9 @@ $(document).ready(function() {
         $("#apply-entity").hide();
         $("#apply-fla").show();
         $("#apply-fla-entity").show();
+        // set config option // hard-coded for now as $("#fsfe-compliance").val() has weird inconsistent results
+        configs["fsfe-compliance"] = "fsfe-compliance";
     }
-
-    // FIXME is this needed here? Is there a better place for it? 
-    $( "#non-fsfe-compliance").click(function () {
-        selectNonFsfeCompliance();
-    });
 
     /*
      * Select the options for non-fsfe compliance
@@ -1896,7 +1891,10 @@ $(document).ready(function() {
         }
         $("#outbound-option-4-label").show();
         $("#outbound-option-5-label").show();
-        $("#outbound-option-fsfe").prop("checked", true);
+        // FIXME disabled this, as it was prevening from loading query string/configs properly
+        //if ( !!$('#outbound-option-license-policy').val() || !!$('#outbound-option-no-commitment').val() || !!$('#outbound-option-same-licenses').val() || !!($('#outbound-option-same').val() ) ) {
+        //$("#outbound-option-fsfe").prop("checked", true); 
+        //    }
         $("#outboundlist").hide();
         $("#outboundlist-custom").hide();
         $("#license-policy-location").hide();
@@ -1905,6 +1903,7 @@ $(document).ready(function() {
         $("#patent-type-fsfe").hide();
         // FIXME Probably remove adding patent pledge here, as it then exists double
         $('<option id="patent-pledge" value="Patent-Pledge">Identified Patent Pledge</option>').appendTo("#patent-type");
+        // FIXME this probably also has to be remove, as
         $('select[name*="patent-type"] option[value="Traditional"]').prop('selected', true);
         $("#review-media-licenses-line").show();
         $("#review-text").closest( "ul" ).show();
@@ -1915,7 +1914,18 @@ $(document).ready(function() {
         $("#apply-entity").show();
         $("#apply-fla").hide();
         $("#apply-fla-entity").hide();
+        configs["fsfe-compliance"] = "non-fsfe-compliance";
     }
+
+
+    // this should prob be under general page (and maybe use change for consistency)
+    $( "#fsfe-compliance").click(function() {
+        selectFsfeCompliance();
+    });
+
+    $( "#non-fsfe-compliance").click(function () {
+        selectNonFsfeCompliance();
+    });
 
     /*
      * This function shows the media list for CLA (non-fsfe) and hides it for FLA (fsfe)
@@ -1947,7 +1957,6 @@ $(document).ready(function() {
 
     /*
     * On changing the outbound-option same licenses, show relevant UI elements
-    * FIXME This is the same for both, so should be reduced
     */
 
     $( "#outbound-option-same-licenses" ).change(function() {

--- a/tests/agreementTests.js
+++ b/tests/agreementTests.js
@@ -1,5 +1,3 @@
-//const Page = require('./pageobjects/page');
-//const ApplyPage = require('./pageobjects/apply.page')
 const AgreementPage = require('./pageobjects/agreement.page')
 const { expect } = require('chai');
 const agreementPage = new AgreementPage()
@@ -14,6 +12,7 @@ describe('The length of each document version should be correct', async function
         await agreementPage.goThroughAll();
     });
 
+    // TODO make a helper function that comppiles an array of all numbering, and checks it
     it('the fla version (html) with default values should have the right length', async function() {
         await expect(agreementPage.applyResultHtmlFlaText).to.exist;
         let t = await agreementPage.applyResultHtmlFlaText.getValue();
@@ -74,11 +73,11 @@ describe('The length of each document version should be correct', async function
         console.log('STUB: testing if the length of cla-outbound option 5 is correct')
     })
 
-    
+
     it('the cla version with outbound option 1 patent pledge should be correct', async function() {
         console.log('STUB: testing if the length of cla-outbound option 1 is correct')
     })
-    
+
     it('the cla version with outbound option 2 patent pledge should be correct', async function() {
         console.log('STUB: testing if the length of cla-outbound option 2 is correct')
     })
@@ -114,11 +113,13 @@ describe('The length of each document version should be correct', async function
         await expect(url).to.exist;
         var url_length = await agreementPage.getLinkFlaLength();
         console.log(`url length is ${url_length}`)
-        await expect(url_length).to.equal(388);
+        await expect(url_length).to.equal(403);
     })
 });
 
 // FIXME add proper testing of all parameters. add license-policy
+// could also add custom matcher (expect) such as expect.hasUrlParameter
+// or expect.hasConfigValue
 describe('the url parameters should be correct', async function () {
     describe('all parameters should be present', async function () {
          beforeEach(async function() {
@@ -133,8 +134,8 @@ describe('the url parameters should be correct', async function () {
             console.log(`There are ${searchParams.size} parameters`)
             for (const p of searchParams) {
                 console.log(p);
-                
             }
+            await expect(searchParams.size).to.equal(21);
         })
     })
 })


### PR DESCRIPTION
* ensured fsfe-compliance/non-fsfe-compliance and outbound-option-license-policy are saved/loaded to/from configs variable and url
* ensured both are properly reflected in the UI
* and are not overridden by 'default' values