### PR TITLE
Fix FSF license list link

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 <div id="outbound-option-1-label" data-toggle="popover" data-trigger="hover" title="FSF Licenses and OSI Licenses" data-content="Refers to the list of licenses recommended by FSF and OSI. If you are not familiar with these organizations, please visit their websites."> <!-- make either/or possible? -->
 <label class="radio">
 <input type="radio" name="outbound-options" id="outbound-option-fsfe" value="Use FSF and OSI Approved Licenses">
-<strong>Option 1</strong> - The contribution(s) can be licensed under the terms of any licenses the Free Software Foundation classifies as <a href="https://www.gnu.org/licenses/recommended-copylefts.html" title="Free Software Licenses">Free Software Licenses</a> and which are approved by the Open Source Initiative as <a href="https://opensource.org/licenses" title="Open Source Licenses">Open Source licenses</a>.
+<strong>Option 1</strong> - The contribution(s) can be licensed under the terms of any licenses the Free Software Foundation classifies as <a href="https://www.gnu.org/licenses/license-list.html" title="Free Software Licenses">Free Software Licenses</a> and which are approved by the Open Source Initiative as <a href="https://opensource.org/licenses" title="Open Source Licenses">Open Source licenses</a>.
 </label>
 </div>
 


### PR DESCRIPTION
It was previously linking just to their recommended copyleft licenses, not all the ones they classify as free software licenses.